### PR TITLE
Repaired ConnectionRequest-related tests

### DIFF
--- a/incollege/controllers/ConnectionsController.py
+++ b/incollege/controllers/ConnectionsController.py
@@ -35,8 +35,8 @@ def configure_connection_routes(app):
     @token_required
     def handle_conn_status_change(token):
         data = request.get_json()
-        sender_user_id = token.user_id
-        recipient_user_id = data.get('recipient_user_id')
+        sender_user_id = data.get('sender_user_id')
+        recipient_user_id = token.user_id
         status = data.get('status')
         ConnectionsService.update_connection_request(sender_user_id, recipient_user_id, status)
         return jsonify()

--- a/incollege/repositories/ConnectionsRepository.py
+++ b/incollege/repositories/ConnectionsRepository.py
@@ -12,33 +12,36 @@ def create_connection_request(connection_request):
 
 
 def get_requests_by_sender_and_recipient_user_id(sender_user_id, recipient_user_id):
-    results = UNIVERSAL.get_objects_intersection({'sender_user_id': sender_user_id,
-                                                  'recipient_user_id': recipient_user_id})
-    if results:
-        return results[0]
+    result = UNIVERSAL.get_objects_intersection({'sender_user_id': sender_user_id,
+                                                 'recipient_user_id': recipient_user_id})
+    if result:
+        return result
 
 
-def get_pending_requests_by_recipient_id(recipient_user_id):
-    results = UNIVERSAL.get_objects_intersection({'recipient_user_id': recipient_user_id,
-                                                  'status': ConnectionRequestStatus.PENDING})
-    return results
+def get_pending_requests_by_recipient_user_id(recipient_user_id):
+    result = UNIVERSAL.get_objects_intersection({'recipient_user_id': recipient_user_id,
+                                                 'status': ConnectionRequestStatus.PENDING})
+    if result:
+        return result
 
 
-def get_pending_requests_by_sender_id(sender_user_id):
-    results = UNIVERSAL.get_objects_intersection({'recipient_user_id': sender_user_id,
-                                                  'status': ConnectionRequestStatus.PENDING})
-    return results
+def get_pending_requests_by_sender_user_id(sender_user_id):
+    result = UNIVERSAL.get_objects_intersection({'sender_user_id': sender_user_id,
+                                                 'status': ConnectionRequestStatus.PENDING})
+    if result:
+        return result
 
 
 def get_connections_by_user_id(user_id):
-    result_receiver = UNIVERSAL.get_objects_intersection({'recipient_user_id': user_id,
-                                                          'status': ConnectionRequestStatus.ACCEPTED})
     result_sender = UNIVERSAL.get_objects_intersection({'sender_user_id': user_id,
                                                         'status': ConnectionRequestStatus.ACCEPTED})
+    result_recipient = UNIVERSAL.get_objects_intersection({'recipient_user_id': user_id,
+                                                           'status': ConnectionRequestStatus.ACCEPTED})
 
-    results = result_sender + result_receiver
+    results = result_sender + result_recipient
 
-    return results
+    if results:
+        return results
 
 
 def update_connection_request(mutated_connection_request):

--- a/incollege/services/ConnectionsService.py
+++ b/incollege/services/ConnectionsService.py
@@ -10,7 +10,7 @@ def send_connection_request(sender_user_id, recipient_user_id):
 
 
 def get_pending_requests_by_recipient_user_id(recipient_user_id):
-    result = ConnectionsRepository.get_pending_requests_by_recipient_id(recipient_user_id)
+    result = ConnectionsRepository.get_pending_requests_by_recipient_user_id(recipient_user_id)
     if not result:
         raise ContentException("No matching connection requests found.", 404)
     return result

--- a/tests/controllers/unit/ConnectionsControllerUnit_test.py
+++ b/tests/controllers/unit/ConnectionsControllerUnit_test.py
@@ -5,10 +5,12 @@ from flask import Flask
 
 from incollege.controllers.ConnectionsController import configure_connection_routes
 from incollege.controllers.ControllerAdvice import configure_controller_advice
+from incollege.entity.AuthJWT import AuthJWT
 from incollege.services import AuthService
 
-test_jwt_header = {'token': AuthService.create_token('some_user_id', 'user')}
+test_jwt_header = {'token': AuthJWT('some_user_id', 'user').encode()}
 test_invalid_jwt_header = {'token': 'invalid_token'}
+
 
 @pytest.fixture(scope='module')
 def test_client():
@@ -21,48 +23,59 @@ def test_client():
         with app.app_context():
             yield client
 
+
 def get_response_error_desc(response):
     return json.loads(response.data)['error']['description']
 
+
 def get_response_message(response):
     return json.loads(response.data)['message']
+
 
 @mock.patch('incollege.services.ConnectionsService.send_connection_request')
 def test_send_connection_request_success(mock_send_request, test_client):
     receiver_userID = 'receiver_user_id'
     response = test_client.post('/send_request', json={'receiver_userID': receiver_userID}, headers=test_jwt_header)
-    
+
     assert response.status_code == 200
     mock_send_request.assert_called_once_with('some_user_id', receiver_userID)
 
-@mock.patch('incollege.services.ConnectionsService.get_requests_list', return_value=[])
-def test_get_requests_list_success(mock_get_requests, test_client):
+
+@mock.patch('incollege.services.ConnectionsService.get_pending_requests_by_recipient_user_id',
+            return_value=[])
+def test_get_pending_requests_by_recipient_user_id_success(mock_get_pending_requests_by_recipient_user_id,
+                                                           test_client):
     response = test_client.post('/get_requests_list', headers=test_jwt_header)
-    
+
     assert response.status_code == 200
     assert get_response_message(response) == []
-    mock_get_requests.assert_called_once_with('some_user_id')
+    mock_get_pending_requests_by_recipient_user_id.assert_called_once_with('some_user_id')
 
-@mock.patch('incollege.services.ConnectionsService.get_accepted_list', return_value=[])
-def test_get_accepted_list_success(mock_get_accepted, test_client):
+
+@mock.patch('incollege.services.ConnectionsService.get_connections_by_user_id', return_value=[])
+def test_get_accepted_list_success(mock_get_connections_by_user_id, test_client):
     response = test_client.post('/get_accepted_list', headers=test_jwt_header)
-    
+
     assert response.status_code == 200
     assert get_response_message(response) == []
-    mock_get_accepted.assert_called_once_with('some_user_id')
+    mock_get_connections_by_user_id.assert_called_once_with('some_user_id')
 
-@mock.patch('incollege.services.ConnectionsService.change_conn_status')
-def test_handle_conn_status_change_success(mock_change_status, test_client):
-    request_id = 'request_id'
+
+@mock.patch('incollege.services.ConnectionsService.update_connection_request')
+def test_handle_conn_status_change_success(mock_update_connection_request, test_client):
+    sender_id = 'sender_id'
     status = 'accepted'
-    response = test_client.post('/change_conn_status', json={'request_id': request_id, 'status': status}, headers=test_jwt_header)
-    
+    response = test_client.post('/change_conn_status', json={'sender_user_id': sender_id, 'status': status},
+                                headers=test_jwt_header)
+
     assert response.status_code == 200
-    mock_change_status.assert_called_once_with(request_id, status)
+    mock_update_connection_request.assert_called_once_with(sender_id, 'some_user_id', status)
+
 
 @mock.patch('incollege.services.ConnectionsService.send_connection_request')
 def test_send_connection_request_unauthorized(mock_send_request, test_client):
     receiver_userID = 'receiver_user_id'
-    response = test_client.post('/send_request', json={'receiver_userID': receiver_userID}, headers=test_invalid_jwt_header)
-    
+    response = test_client.post('/send_request', json={'receiver_userID': receiver_userID},
+                                headers=test_invalid_jwt_header)
+
     assert response.status_code == 401


### PR DESCRIPTION
Fixed testing code to actually mock database returns, aligned with entity and repository changes